### PR TITLE
Check for update on application start

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,5 @@
 pyinstaller==3.4.0
 wxpython==4.0.3
 pyxform==0.14.0
+requests==2.22.0
+packaging==19.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ wxpython==4.0.3
 pyxform==0.14.0
 requests==2.22.0
 packaging==19.1
+markdown2==2.3.8

--- a/src/main.py
+++ b/src/main.py
@@ -62,7 +62,7 @@ OS_MAP = {
 class UpdateChecker(threading.Thread):
 
     def get_update_information(self):
-        response = requests.get(GITHUB_RELEASES_API)
+        response = requests.get(GITHUB_RELEASES_API, timeout=30)
         if response.status_code == 200:
             json_response = response.json()
             latest_version = json_response["tag_name"]
@@ -322,7 +322,7 @@ class MainFrame(wx.Frame):
         self.Centre()
         self.Show()
 
-        self.check_update_and_show()
+        threading.Thread(target=self.check_update_and_show, args=()).start()
 
     @staticmethod
     def shorten_string(string, max_length):

--- a/src/main.py
+++ b/src/main.py
@@ -28,8 +28,8 @@ MAIN_WINDOW_WIDTH = 475
 MAIN_WINDOW_HEIGHT = 620
 ABOUT_WINDOW_WIDTH = 360
 ABOUT_WINDOW_HEIGHT = 335
-UPDATE_WINDOW_WIDTH = 330
-UPDATE_WINDOW_HEIGHT = 135
+UPDATE_WINDOW_WIDTH = 360
+UPDATE_WINDOW_HEIGHT = 335
 MAX_PATH_LENGTH = 45
 HEADER_SPACER = 6
 CHOOSE_BORDER = 5
@@ -41,8 +41,8 @@ if sys.platform == 'darwin':
     MAIN_WINDOW_HEIGHT = 750
     ABOUT_WINDOW_WIDTH = 360
     ABOUT_WINDOW_HEIGHT = 290
-    UPDATE_WINDOW_WIDTH = 330
-    UPDATE_WINDOW_HEIGHT = 100
+    UPDATE_WINDOW_WIDTH = 360
+    UPDATE_WINDOW_HEIGHT = 290
     MAX_PATH_LENGTH = 40
     HEADER_SPACER = 0
     CHOOSE_BORDER = 1
@@ -71,7 +71,7 @@ class UpdateAvailableFrame(wx.Frame):
         with open(update_html_path, 'r') as file:
             update_html_text = file.read()
 
-        filled_update_html_text = update_html_text.replace('@latest_version', update_info['latest_version']).replace(
+        filled_update_html_text = update_html_text.replace('@desc', update_info['update_desc']).replace(
             '@download_url', update_info['download_url']).replace('@download_name', update_info['download_name'])
 
         html.SetPage(filled_update_html_text)

--- a/src/main.py
+++ b/src/main.py
@@ -58,10 +58,25 @@ OS_MAP = {
     'darwin': 'macos'
 }
 
+update_checker_event = wx.NewEventType()
+on_update_checker_done = wx.PyEventBinder(update_checker_event, 1)
+
+
+class UpdateCheckDoneEvent(wx.PyCommandEvent):
+    def __init__(self, etype, eid, value=None):
+        wx.PyCommandEvent.__init__(self, etype, eid)
+        self.update_info = value
+
+    def GetUpdateInfo(self):
+        return self.update_info
+
 
 class UpdateChecker(threading.Thread):
+    def __init__(self, parent):
+        threading.Thread.__init__(self)
+        self._parent = parent
 
-    def get_update_information(self):
+    def run(self):
         response = requests.get(GITHUB_RELEASES_API, timeout=30)
         if response.status_code == 200:
             json_response = response.json()
@@ -74,17 +89,18 @@ class UpdateChecker(threading.Thread):
                     if OS_MAP[sys.platform] in asset['name'].lower():
                         download_url = asset['browser_download_url']
                         download_name = asset['name']
+                        break
 
-                return {
+                wx.PostEvent(self._parent, UpdateCheckDoneEvent(update_checker_event, -1, {
                     'update_available': True,
                     'latest_version': latest_version,
                     'download_url': download_url,
                     'download_name': download_name
-                }
+                }))
             else:
-                return {
+                wx.PostEvent(self._parent, UpdateCheckDoneEvent(update_checker_event, -1, {
                     'update_available': False
-                }
+                }))
 
 
 class UpdateAvailableFrame(wx.Frame):
@@ -322,7 +338,8 @@ class MainFrame(wx.Frame):
         self.Centre()
         self.Show()
 
-        threading.Thread(target=self.check_update_and_show, args=()).start()
+        self.Bind(on_update_checker_done, self.check_update_and_show)
+        UpdateChecker(self).start()
 
     @staticmethod
     def shorten_string(string, max_length):
@@ -420,12 +437,10 @@ class MainFrame(wx.Frame):
         if self.result_thread is not None and self.result_thread.isAlive():
             self.status_gauge.Pulse()
 
-    def check_update_and_show(self):
-        update_info = UpdateChecker().get_update_information()
-
+    def check_update_and_show(self, event):
         if self.update_window:
             self.update_window.Close()
-        self.update_window = UpdateAvailableFrame(None, update_info)
+        self.update_window = UpdateAvailableFrame(None, event.GetUpdateInfo())
         self.update_window.Centre()
         self.update_window.Show()
 

--- a/src/res/update.html
+++ b/src/res/update.html
@@ -1,15 +1,19 @@
 <!DOCTYPE html PUBLIC "-//W3C//DTD HTML 3.2//EN">
 <html>
 
-	<head>
-		<title></title>
-	</head>
+<head>
+	<title></title>
+</head>
 
-	<body>
-		<p>
-			Update @latest_version is available. Click to download. <br /><br />
-			<a href="@download_url">@download_name</a>
-		</p>
-	</body>
+<body>
+	<p>
+		@desc
+		<br />
+		<br />
+		<br />
+		<b>Download</b><br />
+		<a href="@download_url">@download_name</a>
+	</p>
+</body>
 
 </html>

--- a/src/res/update.html
+++ b/src/res/update.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD HTML 3.2//EN">
+<html>
+
+	<head>
+		<title></title>
+	</head>
+
+	<body>
+		<p>
+			Update @latest_version is available. Click to download. <br /><br />
+			<a href="@download_url">@download_name</a>
+		</p>
+	</body>
+
+</html>

--- a/src/update_checker.py
+++ b/src/update_checker.py
@@ -1,0 +1,66 @@
+import wx
+import sys
+
+import requests
+from packaging import version
+import threading
+
+GITHUB_RELEASES_API = "https://api.github.com/repos/opendatakit/xlsform-offline/releases/latest"
+
+OS_MAP = {
+    'win32': 'windows',
+    'darwin': 'macos'
+}
+
+EVT_UPDATE_CHECKER = wx.NewId()
+
+
+def evt_update_check_done(win, func):
+    '''Define Update Check Done Event.'''
+    win.Connect(-1, -1, EVT_UPDATE_CHECKER, func)
+
+
+class UpdateCheckDoneEvent(wx.PyEvent):
+    '''Simple event to check for updates.'''
+
+    def __init__(self, data):
+        '''Init Update Check Done Event.'''
+        wx.PyEvent.__init__(self)
+        self.SetEventType(EVT_UPDATE_CHECKER)
+        self.data = data
+
+
+class UpdateChecker(threading.Thread):
+    def __init__(self, parent, current_version):
+        threading.Thread.__init__(self)
+        self._parent = parent
+        self._current_version = current_version
+
+    def run(self):
+        try:
+            response = requests.get(GITHUB_RELEASES_API, timeout=30)
+            if response.status_code == 200:
+                json_response = response.json()
+                latest_version = json_response["tag_name"]
+                print(latest_version)
+                if version.parse(latest_version[1:]) > version.parse(self._current_version[1:]):
+                    download_url = ''
+                    download_name = ''
+                    for asset in json_response['assets']:
+                        if OS_MAP[sys.platform] in asset['name'].lower():
+                            download_url = asset['browser_download_url']
+                            download_name = asset['name']
+                            break
+
+                    wx.PostEvent(self._parent, UpdateCheckDoneEvent({
+                        'update_available': True,
+                        'latest_version': latest_version,
+                        'download_url': download_url,
+                        'download_name': download_name
+                    }))
+                else:
+                    wx.PostEvent(self._parent, UpdateCheckDoneEvent({
+                        'update_available': False
+                    }))
+        except Exception as ex:
+            pass

--- a/src/update_checker.py
+++ b/src/update_checker.py
@@ -4,6 +4,7 @@ import sys
 import requests
 from packaging import version
 import threading
+import markdown2
 
 GITHUB_RELEASES_API = "https://api.github.com/repos/opendatakit/xlsform-offline/releases/latest"
 
@@ -56,11 +57,13 @@ class UpdateChecker(threading.Thread):
                         'update_available': True,
                         'latest_version': latest_version,
                         'download_url': download_url,
-                        'download_name': download_name
+                        'download_name': download_name,
+                        'update_desc': markdown2.markdown(json_response["body"].replace('\n', '<br/>'))
                     }))
                 else:
                     wx.PostEvent(self._parent, UpdateCheckDoneEvent({
                         'update_available': False
                     }))
         except Exception as ex:
+            print ex
             pass


### PR DESCRIPTION
This PR aims to resolve issue #13 

1) In a background thread, it will hit the github releases api to get the latest release
2) If new version is greater, based on the OS (MacOS or windows), correct asset url is picked and displayed in a dialog box as a link.
3) Also along with the link, github release description will be converted from markdown to html and displayed in the update dialog box.

![update_checker_4](https://user-images.githubusercontent.com/9017268/62391629-fa3a2000-b582-11e9-8304-e994c253774f.gif)
