### PR TITLE
Update Travis and Update to Python 3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,39 +1,62 @@
 language: python
 dist: xenial
+env:
+  global:
+  - BINARY_VERSION=$(git describe --tags --dirty --always)
 
-python:
-  - "2.7"
-
-addons:
-  artifacts:
-    paths:
-      - ./dist/mac/ODK-XLSForm-Offline-macOS.zip
-      - ./dist/win
-    target_paths:
-      - ${TRAVIS_BUILD_NUMBER}
-    debug: true
-
-matrix:
+jobs:
   include:
-    - os: osx
+    - stage: Build binaries
+      os: osx
       language: sh
-      python: "2.7"
+      python: 
+        - "3.6"
       before_install:
         - brew update
         - brew install unix2dos
-        - pip install pyinstaller wxpython pyxform
+        - pip3 install pyinstaller wxpython pyxform
       script:
         - ./make-mac.sh
-        - ./make-dist.sh
+      workspaces:
+        create:
+          name: mac-binaries
+          paths:
+            - ./dist/mac/ODK-XLSForm-Offline.app
     - os: windows
       language: sh
-      python: "2.x"
+      python: 
+        - "3.6"
       before_install:
-        - choco install python2 --params "/InstallDir:C:\\Python"
+        - choco install python3 --params "/InstallDir:C:\\Python"
         - export PATH="/c/Python:/c/Python/Scripts:$PATH"
-        - pip install pyinstaller
-        - pip install pyxform
+        - pip3 install pyinstaller
+        - pip3 install pyxform
       script:
         - ./make-win.bat
+      workspaces:
+        create:
+          name: windows-binaries
+          paths: 
+            - ./dist/win/ODK-XLSForm-Offline.exe
+    - stage: Deploy
+      os: osx
+      language: sh
+      workspaces:
+        use:
+          - mac-binaries
+          - windows-binaries
+      before_install:
+        - brew update
+        - brew install unix2dos
+      script:
+        - ./make-dist.sh
+      addons:
+        artifacts:
+          paths:
+            - ./dist/mac/ODK-XLSForm-Offline-macOS-${BINARY_VERSION}.zip
+            - ./dist/win/ODK-XLSForm-Offline-Windows-${BINARY_VERSION}.zip
+          target_paths:
+            - ${TRAVIS_BUILD_NUMBER}
+          debug: true
 
 cache: pip

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 ![Platform](https://img.shields.io/badge/platform-Python-blue.svg)
 [![License](https://img.shields.io/badge/license-Apache%202.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
 [![Slack status](http://slack.opendatakit.org/badge.svg)](http://slack.opendatakit.org)
-![Build status](https://travis-ci.com/opendatakit/xlsform-offline.svg?branch=master)
+[![Build status](https://travis-ci.com/opendatakit/xlsform-offline.svg?branch=travis)](https://travis-ci.com/opendatakit/xlsform-offline)
 
 ODK XLSForm Offline is a Windows and macOS application for converting an XLSForm into an XForm that is compliant with the [ODK XForms spec](http://opendatakit.github.io/xforms-spec). Once converted, the application also validates that the XForm will run perfectly with all ODK tools.
    
@@ -16,9 +16,9 @@ ODK XLSForm Offline is part of Open Data Kit (ODK), a free and open-source set o
 
 ## Prerequisites
 
-1. Install [Python 2.7](https://www.python.org/downloads/)
+1. Install [Python 3.6](https://www.python.org/downloads/)
 	* Windows: Use the 32 bit version.
-1. Install Python packages: ``pip install pyinstaller wxpython pyxform``
+1. Install Python packages: ``pip3 install pyinstaller wxpython pyxform``
 	* macOS: Use the default Python. virtualenvs will not work.
 1. Install packaging utilities
 	* macOS: ``brew install unix2dos``
@@ -36,3 +36,26 @@ The easiest way to package is to use a macOS machine running a Windows 10 virtua
 1. In the Windows VM, run `make-win.bat` to build the Windows binary.
 1. Copy the resulting binaries into the `dist/mac` and `dist/win` folders on the host machine.
 1. On the host machine, run `./make-dist.sh` to zip up the Mac and Windows binaries.
+
+# Build Location 
+
+If you're building on [travis](https://travis-ci.com/), the MacOS zip file will be output to 
+
+http://travis-opendatakit-org.s3-website-us-west-2.amazonaws.com/{TRAVIS_BUILD_NUMBER}/dist/mac/ODK-XLSForm-Offline-macOS-{GIT_HASH}.zip
+
+And the windows to
+
+http://travis-opendatakit-org.s3-website-us-west-2.amazonaws.com/{TRAVIS_BUILD_NUMBER}/dist/win/ODK-XLSForm-Offline-Windows-{GIT_HASH}.zip
+
+Where {TRAVIS_BUILD_NUMBER} should be replaced with the actual build number, and {GIT_HASH} should be replaced with the output of the command 
+```shell 
+git describe --tags --dirty --always
+```
+For example, if I were on [build #119](https://travis-ci.com/github/shouryaj/xlsform-offline/builds/159146104), then the output of the `git hash` command would be:
+```
+v1.7.0-15-g2cf312f
+```
+and to download the mac binary, I would go to:
+http://travis-opendatakit-org.s3-website-us-west-2.amazonaws.com/119/dist/mac/ODK-XLSForm-Offline-macOS-v1.7.0-15-g2cf312f.zip
+for the windows binary, I would go to:
+http://travis-opendatakit-org.s3-website-us-west-2.amazonaws.com/119/dist/win/ODK-XLSForm-Offline-Windows-v1.7.0-15-g2cf312f.zip

--- a/make-dist.sh
+++ b/make-dist.sh
@@ -1,15 +1,46 @@
+  
 #!/bin/bash
 set -e
 
+VERSION=$(git describe --tags --dirty --always)
+
 README='pkg/Read me.txt'
 
-MAC_BINARY='dist/mac/ODK XLSForm Offline.app'
-MAC_README='dist/mac/Read me.txt'
+CWD=$(pwd)
+
+MAC_BINARY="dist/mac/ODK-XLSForm-Offline.app"
+MAC_README="dist/mac/Read me.txt"
+
+# Travis workspaces is weird with windows
+WIN_DIR="C:${CWD}/dist/win"
+WIN_BINARY="${WIN_DIR}/ODK-XLSForm-Offline.exe"
+WIN_README="${WIN_DIR}/Read me.txt"
 
 if [[ -e "$MAC_BINARY" ]]; then
 	echo 'Mac version exists';
 	fold -w 80 -s "$README" > "$MAC_README";
 	cd dist/mac;
-	zip -r9 "ODK-XLSForm-Offline-macOS.zip" . -x "*.DS_Store"
-	cd ../..;
+	mv "ODK-XLSForm-Offline.app" "ODK XLSForm Offline.app" 
+	# Add the binary version in the zip name
+	zip -r9 "ODK-XLSForm-Offline-macOS-${VERSION}.zip" . -x "*.DS_Store"
+	echo "ODK-XLSForm-Offline-macOS-${VERSION}.zip"
+	cd $CWD;
+fi
+
+if [[ -e "$WIN_BINARY" ]]; then
+	if ! [[ -d dist ]]; then
+		mkdir dist
+	fi
+	mkdir dist/win
+	echo 'Windows version exists';
+	fold -w 80 -s "$README" > "$WIN_README";
+	mac2unix "$WIN_README" && unix2dos "$WIN_README";
+	cd $WIN_DIR;
+	ls
+	mv "ODK-XLSForm-Offline.exe" "ODK XLSForm Offline.exe"
+	zip -r9 "ODK-XLSForm-Offline-Windows.zip" . -x "*.DS_Store"
+	# Add the binary version in the zip name
+	mv "ODK-XLSForm-Offline-Windows.zip" "$CWD/dist/win/ODK-XLSForm-Offline-Windows-${VERSION}.zip"
+	echo "$CWD/dist/win/ODK-XLSForm-Offline-Windows-${VERSION}.zip"
+	cd $CWD;
 fi

--- a/make-win.bat
+++ b/make-win.bat
@@ -1,4 +1,5 @@
+pip install PyInstaller wxpython pyxform
 rd /s /q build\xlsform-offline-win 
 rd /s /q dist\win
 del /s /q *.pyc
-pyinstaller pkg\xlsform-offline-win.spec --distpath dist\win --onefile --windowed --noconfirm --clean
+python -m PyInstaller pkg\xlsform-offline-win.spec --distpath dist\win --onefile --windowed --noconfirm --clean

--- a/pkg/xlsform-offline-mac.spec
+++ b/pkg/xlsform-offline-mac.spec
@@ -10,23 +10,30 @@ for path in site.getsitepackages():
         iana_path = test_iana_path
 
 a = Analysis(['../src/main.py'])
-pyz = PYZ(a.pure)
+pyz = PYZ(a.pure, a.zipped_data)
 exe = EXE(pyz,
           a.scripts,
+          [],
           exclude_binaries=True,
           name='ODK XLSForm Offline',
-          console=False
-)
+          debug=False,
+          bootloader_ignore_signals=False,
+          strip=False,
+          upx=True,
+          console=False )
 coll = COLLECT(exe,
                a.binaries,
+               a.zipfiles,
+               a.datas,
                [('res/about.html', os.getcwd() + '/src/res/about.html', 'DATA')],
                [('pyxform/validators/odk_validate/bin/ODK_Validate.jar', validate_path, 'DATA')],
                [('pyxform/iana_subtags.txt', iana_path, 'DATA')],
-               name='ODK XLSForm Offline',
-               strip=True
-)
+               strip=False,
+               upx=True,
+               upx_exclude=[],
+               name='ODK XLSForm Offline')
 app = BUNDLE(coll,
-             name='ODK XLSForm Offline.app',
+             name='ODK-XLSForm-Offline.app',
              icon='icon.icns',
-             info_plist={ 'NSHighResolutionCapable': 'True' }
-)
+             info_plist={ 'NSHighResolutionCapable': 'True' },
+             bundle_identifier=None)

--- a/pkg/xlsform-offline-win.spec
+++ b/pkg/xlsform-offline-win.spec
@@ -1,7 +1,7 @@
 # -*- mode: python -*-
-
 import site;
 for path in site.getsitepackages():
+    path = path.replace("lib", "Lib")
     test_validate_path = os.path.join(path, 'pyxform/validators/odk_validate/bin/ODK_Validate.jar')
     if os.path.exists(test_validate_path):
         validate_path = test_validate_path
@@ -9,15 +9,19 @@ for path in site.getsitepackages():
     if os.path.exists(test_iana_path):
         iana_path = test_iana_path
 
-a = Analysis(['../src/main.py'])
-pyz = PYZ(a.pure)
+
+
+a = Analysis(['..\\src\\main.py'])
+pyz = PYZ(a.pure, a.zipped_data)
 exe = EXE(pyz,
           a.scripts,
           a.binaries,
+          a.zipfiles,
+          a.datas,
           [('res\\about.html', os.getcwd() + '\\src\\res\\about.html', 'DATA')],
           [('pyxform\\validators\\odk_validate\\bin\\ODK_Validate.jar', validate_path, 'DATA')],
           [('pyxform\\iana_subtags.txt', iana_path, 'DATA')],
-          name='ODK XLSForm Offline.exe',
+          name='ODK-XLSForm-Offline.exe',
           icon='icon.ico',
           upx=True,
           console=False

--- a/src/main.py
+++ b/src/main.py
@@ -312,7 +312,7 @@ class MainFrame(wx.Frame):
             self.status_text_ctrl.AppendText(event.data)
 
     def on_progress(self, event):
-        if self.result_thread is not None and self.result_thread.isAlive():
+        if self.result_thread is not None and self.result_thread.is_alive():
             self.status_gauge.Pulse()
 
     @staticmethod
@@ -325,7 +325,7 @@ class MainFrame(wx.Frame):
             startupinfo.dwFlags |= subprocess.STARTF_USESHOWWINDOW
 
         java_version = None
-        java_regex = re.compile('(java|openjdk) version')
+        java_regex = re.compile(b'(java|openjdk) version')
         try:
             java_version = subprocess.Popen(['java', '-version'], stderr=subprocess.PIPE, stdin=subprocess.PIPE,
                                             stdout=subprocess.PIPE, shell=False, startupinfo=startupinfo).communicate()[


### PR DESCRIPTION
@PieterBenjamin, @shouryaj, and I are addressing issue #36, building off the work of @shouryaj in PR #35.

The travis.yml now uses workspaces and stages to have a build stage where the macOS and Windows executables separately and then a deploy stage where these are zipped with the read me and uploaded to the S3 bucket, including the git hash in the compressed files name. 

The generic links to download the binaries are in the README, but feel free to download this [specific build](https://travis-ci.com/github/shouryaj/xlsform-offline/builds/159235359)'s [macOS](http://travis-opendatakit-org.s3-website-us-west-2.amazonaws.com/123/dist/mac/ODK-XLSForm-Offline-macOS-v1.11.1-2-g78af929.zip) or [Windows](http://travis-opendatakit-org.s3-website-us-west-2.amazonaws.com/123/dist/win/ODK-XLSForm-Offline-Windows-v1.11.1-2-g78af929.zip) binaries. 

Further, we updated the python version to Python 3.

I made the status badge in the README point to the travis branch temporarily to test it is working. 

There is a reference on #36  to fix the windows paths, but we aren't sure exactly what that means of if we've addressed it. 